### PR TITLE
updated: gitconfiglocal

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "chalk": "^2.3.0",
-    "git-remote-origin-url": "^2.0.0",
+    "git-remote-origin-url": "^3.0.0",
     "github-label-sync": "^1.3.0",
     "hosted-git-info": "^2.5.0",
     "meow": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,16 +1191,17 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-remote-origin-url@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz#5282659dae2107145a11126112ad3216ec5fa65f"
+git-remote-origin-url@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/git-remote-origin-url/-/git-remote-origin-url-3.0.0.tgz#7561ea24bc16e89b39f96d4302fffb0cd990a1d8"
+  integrity sha512-KXFRTWj4F39zzmeTo4DGDGiZ9dPDsh+HPZiPRQgW0OpnhcmEPSdf3AgLzLqJuuo8t8UGSKKcvK8nmnejWuq3UQ==
   dependencies:
-    gitconfiglocal "^1.0.0"
-    pify "^2.3.0"
+    gitconfiglocal "^2.1.0"
 
-gitconfiglocal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz#41d045f3851a5ea88f03f24ca1c6178114464b9b"
+gitconfiglocal@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-2.1.0.tgz#07c28685c55cc5338b27b5acbcfe34aeb92e43d1"
+  integrity sha512-qoerOEliJn3z+Zyn1HW2F6eoYJqKwS6MgC9cztTLUB/xLWX8gD/6T60pKn4+t/d6tP7JlybI7Z3z+I572CR/Vg==
   dependencies:
     ini "^1.3.2"
 
@@ -1913,10 +1914,6 @@ path-type@^3.0.0:
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-
-pify@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
 pify@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
gitconfiglocalにはセクションが重なるとデータを一部無視してしまうというバグがあり,
私はそれを2019年2月に修正しました.
[fixed: case: after remote without keys by ncaq · Pull Request #9 · soldair/node-gitconfiglocal](https://github.com/soldair/node-gitconfiglocal/pull/9)
しかしこのプロジェクトではgit-remote-origin-urlのアップデートによるバグ修正の恩恵を受けられておらず,
時々このバグに遭遇して困ってしまいます.
なのでアップデートを適用するようお願いいたします.