### PR TITLE
feat: add Type: Release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@ changelog:
     labels:
       - 'Type: Meta'
       - 'Type: Question'
+      - 'Type: Release'
 
   categories:
     - title: Security Fixes

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ These are opinionated labels.
 - ![#cc317c](https://placehold.co/15x15/cc317c/cc317c.png) Type: Question - Further information is requested
 - ![#ee0701](https://placehold.co/15x15/ee0701/ee0701.png) Type: Security - Vulnerability disclosure or Fixing security issue
 - ![#0366d6](https://placehold.co/15x15/0366d6/0366d6.png) Type: Dependencies - Dependency issues or Changes to dependency files
-- ![#0366d6](https://placehold.co/15x15/BFD4F2/BFD4F2.png) Type: Meta - Related repository itself
+- ![#0366d6](https://placehold.co/15x15/BFD4F2/BFD4F2.png) Type: Meta - Related to repository itself (This will not be includes in Release Note)
+- ![#0366d6](https://placehold.co/15x15/5319E7/5319E7.png) Type: Release - Related to release process (This will not be includes in Release Note)
 
 ## Integration with GitHub Releases
 

--- a/labels.json
+++ b/labels.json
@@ -185,5 +185,21 @@
     "aliases": [
       "dependencies"
     ]
+  },
+  {
+    "name": "Type: Meta",
+    "color": "BFD4F2",
+    "description": "Type: Meta - Related to repository itself",
+    "aliases": [
+      "meta"
+    ]
+  },
+  {
+    "name": "Type: Release",
+    "color": "5319E7",
+    "description": "Related to release process",
+    "aliases": [
+      "meta"
+    ]
   }
 ]


### PR DESCRIPTION
Add `Type: Release` label that is related to release process.

`Type: Release` will not be includes Release Notes.
So, I've added it into exclude filed in .github/release.yml.